### PR TITLE
fix: don't add grip MCP tool names to allowed_tools in SDK engine

### DIFF
--- a/grip/engines/sdk_engine.py
+++ b/grip/engines/sdk_engine.py
@@ -361,7 +361,10 @@ class SDKRunner(EngineProtocol):
         # Ensure the custom tool names are in allowed_tools so the SDK permits
         # them.  SDK MCP tools follow the mcp__<server_key>__<tool> convention.
         custom_tool_names = [f"mcp__grip_tools__{t.name}" for t in custom_tools]
-        allowed_tools.extend(custom_tool_names)
+        # Note: do NOT add custom_tool_names to allowed_tools.
+        # Adding them would make allowed_tools non-empty, causing the Claude CLI
+        # to restrict to ONLY those MCP tools and block all built-in tools
+        # (WebSearch, Bash, WebFetch, etc.). Passing None allows everything.
 
         env_opts: dict[str, str] = {
             # Prevent the Claude CLI from refusing to start when grip is


### PR DESCRIPTION
## Problem

In `sdk_engine.py`, the custom grip tool names are added to `allowed_tools`:

```python
custom_tool_names = [f"mcp__grip_tools__{t.name}" for t in custom_tools]
allowed_tools.extend(custom_tool_names)  # ← problem
```

This makes `allowed_tools` non-empty, so the check `allowed_tools if allowed_tools else None` passes the list to `ClaudeAgentOptions` instead of `None`. The Claude CLI then restricts tool access to **only** the listed MCP tools, silently blocking all built-in tools: `WebSearch`, `Bash`, `WebFetch`, `Edit`, `Read`, `Glob`, `Grep`, etc.

## Impact

**All users** of the `claude_sdk` engine are affected. The Claude CLI's built-in tools (Bash, WebFetch, Edit, Read, etc.) are blocked whenever grip has any custom tools registered — which is always.

The agent can still respond, but it cannot execute shell commands, read/write files, or fetch web content. This severely limits the SDK engine's agentic capabilities.

## Fix

Remove the `extend()` call. `allowed_tools` stays empty → evaluates to `None` → Claude CLI allows all built-in tools plus the MCP tools registered via `create_sdk_mcp_server`.

```python
# Before
allowed_tools.extend(custom_tool_names)

# After — removed. MCP tools are accessible via the registered server, not the allow-list.
```

The external MCP server allow-list path (when operators configure specific `allowed_tools` per server) is unchanged and still works correctly.