### PR TITLE
feat: adaptive thinking support via sdk_effort config

### DIFF
--- a/grip/config/schema.py
+++ b/grip/config/schema.py
@@ -131,6 +131,11 @@ class AgentDefaults(BaseModel):
         default="acceptEdits",
         description="SDK permission mode: 'acceptEdits', 'bypassPermissions', or 'default'.",
     )
+    sdk_effort: str | None = Field(
+        default=None,
+        description="Adaptive thinking effort: 'low', 'medium', 'high', or 'max' (Opus 4.6 only). "
+        "Enables adaptive thinking via --effort CLI flag. None = model default.",
+    )
 
 
 class ModelTiersConfig(BaseModel):

--- a/grip/engines/sdk_engine.py
+++ b/grip/engines/sdk_engine.py
@@ -363,6 +363,12 @@ class SDKRunner(EngineProtocol):
         custom_tool_names = [f"mcp__grip_tools__{t.name}" for t in custom_tools]
         allowed_tools.extend(custom_tool_names)
 
+        # Adaptive thinking via --effort flag
+        extra_args: dict[str, str | None] = {}
+        sdk_effort = self._config.agents.defaults.sdk_effort
+        if sdk_effort:
+            extra_args["effort"] = sdk_effort
+
         env_opts: dict[str, str] = {
             # Prevent the Claude CLI from refusing to start when grip is
             # invoked from inside a Claude Code session (nested session guard).
@@ -382,6 +388,7 @@ class SDKRunner(EngineProtocol):
             cwd=self._cwd,
             allowed_tools=allowed_tools if allowed_tools else None,
             env=env_opts if env_opts else None,
+            extra_args=extra_args if extra_args else {},
         )
 
         tool_calls_made: list[str] = []


### PR DESCRIPTION
Adds `sdk_effort` field to `AgentsDefaultsConfig` to enable Claude's adaptive thinking via the `--effort` CLI flag.

**Config:**
```json
{
  "agents": {
    "defaults": {
      "sdk_effort": "medium"
    }
  }
}
```

**Effort levels:**
- `low` — minimal thinking, fastest responses
- `medium` — Claude decides when to think (recommended)
- `high` — Claude almost always thinks (Anthropic default)
- `max` — unconstrained thinking (claude-opus-4-6 only)
- omit / `null` — model default, no `--effort` flag passed

Ref: https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking